### PR TITLE
Fixed sight line enabling condition

### DIFF
--- a/lua/ftFT/init.lua
+++ b/lua/ftFT/init.lua
@@ -101,7 +101,7 @@ function M.execute(key)
     end
 
     -- draw sight line
-    if (not vim.g.ftFT_sight_enable == nil) and vim.v.count1 == 1 then
+    if (not (vim.g.ftFT_sight_enable == nil)) and vim.v.count1 == 1 then
       local bg_str = " "
       vim.api.nvim_buf_set_extmark(0, cur_ns, cur_row + 1, 0, {
         virt_text = {{bg_str, sight_hl_group}},


### PR DESCRIPTION
The sight line didn't seem to work for me until I did this change.

Example of the comparison in action:
![image](https://github.com/gukz/ftFT.nvim/assets/54286003/f0e32616-682d-48a4-8428-ad586d5c8cfc)
